### PR TITLE
Updated to the latest version of jackson-databind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
   <properties>
     <annot8.version>0.2.0-SNAPSHOT</annot8.version>
     <elasticsearch.version>6.4.3</elasticsearch.version>
-    <jackson.version>2.8.10</jackson.version>
+    <jackson.version>2.8.11</jackson.version>
 
     <maven.compiler.source>9</maven.compiler.source>
     <maven.compiler.target>9</maven.compiler.target>


### PR DESCRIPTION
To fix the latest vulnerability report. https://github.com/NationalCrimeAgency/elasticsearch-extract/network/alert/pom.xml/com.fasterxml.jackson.core:jackson-databind/open

2.8.11 should pull in the 2.8.11.3 variant as the latest version and should be a non-breaking change if it updates in the future.